### PR TITLE
Fixing bug in my_init.shutdown_runit_services

### DIFF
--- a/image/bin/my_init
+++ b/image/bin/my_init
@@ -247,7 +247,7 @@ def wait_for_runit_or_interrupt(pid):
 def shutdown_runit_services(quiet = False):
 	if not quiet:
 		debug("Begin shutting down runit services...")
-	os.system("/usr/bin/sv -w %d down /etc/service/*", KILL_PROCESS_TIMEOUT)
+	os.system("/usr/bin/sv -w %d down /etc/service/*" % KILL_PROCESS_TIMEOUT)
 
 def wait_for_runit_services():
 	debug("Waiting for runit services to exit...")


### PR DESCRIPTION
The os.system() call received two arguments from a typo with string formatting.